### PR TITLE
write permission

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -76,6 +76,11 @@ jobs:
           verbose: true
 
   upload-to-pypi:
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     needs: test-built-dist
     if: github.event_name == 'release'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes an important change to the `.github/workflows/deployment.yml` file to enhance the deployment process by specifying a GitHub environment and setting mandatory permissions for trusted publishing.

Enhancements to deployment process:

* [`.github/workflows/deployment.yml`](diffhunk://#diff-5a17873aec4eae6b52b00959d8f9e17672912858f63181d39de8c3a713e90018R79-R83): Added the `environment: release` specification and set the `id-token: write` permission, which is mandatory for trusted publishing.