### PR TITLE
documentation build process

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
 
+      - name: Install
+        uses: pandoc/actions/setup@v1
+        with:
+          version: 2.19
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,7 @@ jobs:
                  sphinxcontrib-restbuilder nbsphinx jupyter_sphinx packaging \
                  jupytext
           cd docs
+          uv run jupytext --to notebook source/**/*.py
           uv run make html
 
       - name: Push Release Docs to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Build documentation
         run: |
+          uv add sphinx "pygments>=2.2.0" "docutils>=0.14" sphinx_rtd_theme \
+                 sphinxcontrib-restbuilder nbsphinx jupyter_sphinx packaging \
+                 jupytext
           cd docs
           uv run make html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get Version
         run: |
-          python docs/get_version.py VERSION.txt
+          uv run python docs/get_version.py VERSION.txt
           cat VERSION.txt >> $GITHUB_ENV
 
       - name: Set version major-minor

--- a/docs/_static/css/tmip_emat.css
+++ b/docs/_static/css/tmip_emat.css
@@ -6,10 +6,10 @@
     max-width: 1200px !important;
 }
 
-.wy-nav-content .section p,
-.wy-nav-content .section ul,
-.wy-nav-content .section dd,
-.wy-nav-content .section dl,
+.wy-nav-content div[role=main] p,
+.wy-nav-content div[role=main] ul,
+.wy-nav-content div[role=main] dd,
+.wy-nav-content div[role=main] dl,
 .wy-nav-content div.admonition,
 .wy-nav-content div.line-block,
 .wy-nav-content div.highlight-default,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ nbsphinx_timeout = 300
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_theme_options = {}
+html_theme_options = {'display_version': True}
 
 # html4_writer=True  # see https://github.com/readthedocs/sphinx_rtd_theme/issues/766
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,10 @@ extensions = [
     'jupyter_sphinx',
 ]
 
+nbsphinx_custom_formats = {
+    ".py": ["jupytext.reads", {"fmt": "py:percent"}],
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,10 +74,6 @@ extensions = [
     'jupyter_sphinx',
 ]
 
-nbsphinx_custom_formats = {
-    ".py": ["jupytext.reads", {"fmt": "py:percent"}],
-}
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/emat.conda.rst
+++ b/docs/source/emat.conda.rst
@@ -23,18 +23,17 @@ More detailed instructions appear below.
 Installing Python
 -----------------
 
-To use TMIP-EMAT, you'll need to have Python 3.7, plus a handful
+To use TMIP-EMAT, you'll need to have Python 3.7 or later, plus a handful
 of other useful statistical packages.  The easiest way to get the basics
-is to download and install the `Anaconda <https://www.anaconda.com/download>`_
-version of Python 3.7. This comes with everything you'll need to get started,
+is to download and install the `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_
+version of Python. This comes with everything you'll need to get started,
 and the Anaconda folks have helpfully curated a selection of useful tools for you,
 so you don't have the sort through the huge selection of tools, both good and bad,
 that are available for Python.
 
 .. note::
 
-    Python has two versions (2 and 3) that are available.
-    TMIP-EMAT is compatible *only* with version 3.
+    TMIP-EMAT is compatible *only* with Python version 3.
 
 You should usually install Anaconda for the local user,
 which does not require administrator permissions.
@@ -76,17 +75,6 @@ is available in the conda documentation itself.
 
 Creating a New Environment for TMIP-EMAT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-
-    If you installed the "Miniconda" version of the anaconda package, or
-    if your main conda installation is a bit out of date, you
-    may need to install or update the *conda* and *anaconda-client* packages
-    before the remote environment installation below will work:
-
-    .. code-block:: console
-
-        conda install -n base -c defaults conda anaconda-client
 
 If you'd like one command to just install TMIP-EMAT and
 the suite of related tools relevant for exploratory modeling and analysis

--- a/docs/source/emat.design/emat.design.py
+++ b/docs/source/emat.design/emat.design.py
@@ -15,6 +15,8 @@
 # ---
 
 # %%
+import numpy as np
+import pandas as pd
 import emat
 emat.versions()
 

--- a/docs/source/emat.install.rst
+++ b/docs/source/emat.install.rst
@@ -20,9 +20,7 @@ source code is recommended.
 
 .. note::
 
-	Python has two versions (2 and 3) but .
-	`only version 3 is currently maintained for most tools <https://python3statement.org>`_.
-	TMIP-EMAT is compatible *only* with version 3.6 or later.
+	TMIP-EMAT is compatible *only* with Python version 3.6 or later.
 
 **Core Model Configuration**
 


### PR DESCRIPTION
This pull request includes several updates to the documentation build process and some minor changes to the documentation styling and configuration. The most important changes are as follows:

### Documentation Build Process Improvements:
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR24-R28): Added a step to install Pandoc using `pandoc/actions/setup@v1` with version 2.19.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL40-R45): Modified the command to get the version using `uv run python docs/get_version.py VERSION.txt` instead of directly running the Python script.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR57-R61): Updated the documentation build step to add several dependencies using `uv add` and included a command to convert Python scripts to Jupyter notebooks with `uv run jupytext --to notebook source/**/*.py`.

### Documentation Styling and Configuration:
* [`docs/_static/css/tmip_emat.css`](diffhunk://#diff-7f3d152fdff6f841a63bc321388e7e8e96bca9be5db6878d0d8fe863e2f28253L9-R12): Adjusted CSS selectors to target `div[role=main]` elements instead of `.section` elements for better styling consistency.
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L131-R131): Enabled the display of the version in the Sphinx theme by setting `html_theme_options = {'display_version': True}`.

### Minor Code Updates:
* [`docs/source/emat.design/emat.design.py`](diffhunk://#diff-57b8de8a2f0abedbd25b3ed25398e0765e0df7be2efaa810ee86e40b4223c4fcR18-R19): Added imports for `numpy` and `pandas` to the script.